### PR TITLE
Add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2024 Christoph Reiter.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository provides Docker images including MSYS2.
 
-# Linux & Wine
+## Linux & Wine
 
 **WARNING:** Package and database signature checks are currently disabled to
 speed up the build process. This Docker image is not recommended for production
@@ -35,6 +35,12 @@ Acknowledgments:
   MSYS2/Cygwin specific changes is developed by [@jhol (Joel
   Holdsworth)](https://github.com/jhol)
 
-# Windows
+## Windows
 
 Would they be useful? Let us know.
+
+## License
+
+Everything in this repository is licensed under the
+[BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) License unless
+otherwise noted.


### PR DESCRIPTION
The only source was inspired by
https://github.com/pojntfx/hydrapp/blob/main/hydrapp/pkg/builders/msi/Dockerfile (Apache-2) but it has been reworked since then, so imo it's fine to ignore it for copyright.

Use BSD-3-Clause since that is used for PKGBUILDs and other dev tools, and it seems good enough.

Fixes #7